### PR TITLE
Minor bug fix so city != state on user input

### DIFF
--- a/frontend/src/components/NewJob.js
+++ b/frontend/src/components/NewJob.js
@@ -147,7 +147,7 @@ const NewJob = () => {
                             <input 
                                 type="text" 
                                 id="state" 
-                                value={city} 
+                                value={state} 
                                 onChange={(e) => setState(e.target.value)}
                                 className='mt-1 w-full border border-gray-300 rounded-lg bg-gray-50 p-2.5 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 transition'
                             />


### PR DESCRIPTION
Minor bug fix so `city` != `state` on user input

before:

<img width="1176" height="1001" alt="image" src="https://github.com/user-attachments/assets/9165ec3e-65c2-4d27-b6bc-c1e3fee45f8f" />

after:

<img width="1176" height="1001" alt="image" src="https://github.com/user-attachments/assets/7a7056d6-677d-4c3d-8bec-3c6b04cf31df" />

Testing:
Tested by running `npm start` successfully to display the above w/ requisite functionality