### PR TITLE
Allow for '+' in new-skill Validation Pattern

### DIFF
--- a/frontend/src/components/NewSkill.js
+++ b/frontend/src/components/NewSkill.js
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlusCircle, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 
 const VALIDATION_PATTERNS = {
-  skillName: /^[a-zA-Z0-9\s\-_()]+$/,
+  skillName: /^[a-zA-Z0-9+\s\-_()]+$/,
   description: /^[^<>&]*$/
 };
 
@@ -52,7 +52,7 @@ const NewSkill = () => {
     } else if (skillName.length > 100) {
       newErrors.skillName = 'Skill name cannot exceed 100 characters';
     }else if (!VALIDATION_PATTERNS.skillName.test(skillName)) {
-      newErrors.skillName = 'Invalid characters. Letters, numbers, spaces, and -_() are allowed.';
+      newErrors.skillName = 'Invalid characters. Letters, numbers, spaces, and +-_() are allowed.';
     }
     
     if (description.length > 500) {


### PR DESCRIPTION
Allow for `+` in `NewSkill` component `VALIDATION_PATTERN`

before:

<img width="1580" height="1140" alt="image" src="https://github.com/user-attachments/assets/a6750d17-837b-4f0f-9717-376dd271b0d6" />

after:

<img width="1580" height="1140" alt="image" src="https://github.com/user-attachments/assets/d0c670d3-133b-4ef6-85ba-1340de4d1028" />

Testing:
Tested by running `npm start` successfully to display the above w/ requisite functionality