### PR TITLE
Remove double identifier declaration

### DIFF
--- a/frontend/src/components/NewJob.js
+++ b/frontend/src/components/NewJob.js
@@ -26,7 +26,6 @@ const NewJob = () => {
     const [skill, setSkill] = useState(skills[0]);
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState('');
-    const token = localStorage.getItem('token');
 
     const navigate = useNavigate();
     const token = localStorage.getItem('token');


### PR DESCRIPTION
Resolve the following

`Line 32:10:  Parsing error: Identifier 'token' has already been declared. (32:10)`

Test: `npm start` w/o crashing